### PR TITLE
update build to use native llvm wasm support

### DIFF
--- a/compile
+++ b/compile
@@ -12,28 +12,9 @@ outfile=$1
 outdir=$(dirname "$outfile")
 cfiles=( "${@:2}" )
 
-outfilename=${outfile%.*}
-bcfile=$outfilename.bc
-sfile=$outfilename.s
-wastfile=$outfilename.wast
-
-bcfiles=()
-changed=false
-for cfile in "${cfiles[@]}"
-do
-	cbcfile=$outdir/${cfile%.*}.bc
-	bcfiles+=("$cbcfile")
-
-	mkdir -p $(dirname "$cbcfile")
-
-	echo "Compiling $cfile to $cbcfile"
-	$llvm_root/clang -emit-llvm --target=wasm32 -nostdlib -nostdlibinc -ffreestanding $CFLAGS -o "$cbcfile" -c "$cfile"
-done
-
-echo "Combining LLVM bitcode files"
-$llvm_root/llvm-link -o "$bcfile" "${bcfiles[@]}"
-
-echo "Assembling final output file"
-$llvm_root/llc -asm-verbose=false $LLCFLAGS -o "$sfile" "$bcfile"
-s2wasm $S2WASMFLAGS -o "$wastfile" "$sfile"
-wast2wasm -o "$outfile" "$wastfile"
+$llvm_root/clang \
+    --target=wasm32-unknown-unknown-wasm \
+    -o $outfile \
+    -nostartfiles \
+    -Wl,--entry=test,--demangle,--allow-undefined-file=src/external.syms \
+    ${cfiles[@]}

--- a/main.js
+++ b/main.js
@@ -36,6 +36,7 @@
 
 			window.instance = instance;
 			console.log('Module instantiated');
+			window.instance.exports.test();
 		});
 	}
 

--- a/src/external.syms
+++ b/src/external.syms
@@ -1,0 +1,6 @@
+printi
+printd
+printf
+printc
+prints
+printptr

--- a/src/mm.c
+++ b/src/mm.c
@@ -2,9 +2,11 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include "memory.h"
 #include "mm.h"
+
+#ifdef MM_DEBUG
 #include "print.h"
+#endif
 
 #define PAGE_SIZE (64 * 1024)
 
@@ -21,6 +23,12 @@ static uintptr_t heap_top;
 static struct block_info *first_block;
 static struct block_info *last_block;
 static struct block_info *first_free_block;
+
+size_t grow_memory(size_t pages) {
+    size_t current_pages = __builtin_wasm_current_memory();
+    __builtin_wasm_grow_memory(pages);
+    return current_pages;
+}
 
 uintptr_t grow_heap(size_t inc) {
 	uintptr_t old_heap_top = heap_top;
@@ -51,6 +59,7 @@ uintptr_t grow_heap(size_t inc) {
 	return old_heap_top;
 }
 
+__attribute__((visibility("default")))
 void mm_init() {
 	current_pages = grow_memory(0);
 	heap_top = current_pages * PAGE_SIZE;


### PR DESCRIPTION
Since `s2wasm` is no more I ported build example to use native llvm build. Also I replaced external `grow_memory` with native wasm intrinsic.

Original wasm build example: https://github.com/yurydelendik/wasmception